### PR TITLE
Feat/add-graph-endpoints

### DIFF
--- a/_project/api/_src/Usecases.ts
+++ b/_project/api/_src/Usecases.ts
@@ -1,8 +1,15 @@
 // codegen:start {preset: barrel, include: ./Usecases/*.ts, import: default}
 import usecasesBlogControllers from "./Usecases/Blog.Controllers.js"
+import usecasesGraphControllers from "./Usecases/Graph.Controllers.js"
 import usecasesHelloWorldControllers from "./Usecases/HelloWorld.Controllers.js"
 import usecasesMeControllers from "./Usecases/Me.Controllers.js"
 import usecasesOperationsControllers from "./Usecases/Operations.Controllers.js"
 
-export { usecasesBlogControllers, usecasesHelloWorldControllers, usecasesMeControllers, usecasesOperationsControllers }
+export {
+  usecasesBlogControllers,
+  usecasesGraphControllers,
+  usecasesHelloWorldControllers,
+  usecasesMeControllers,
+  usecasesOperationsControllers
+}
 // codegen:end

--- a/_project/api/_src/Usecases.ts
+++ b/_project/api/_src/Usecases.ts
@@ -1,7 +1,8 @@
 // codegen:start {preset: barrel, include: ./Usecases/*.ts, import: default}
+import usecasesBlogControllers from "./Usecases/Blog.Controllers.js"
 import usecasesHelloWorldControllers from "./Usecases/HelloWorld.Controllers.js"
 import usecasesMeControllers from "./Usecases/Me.Controllers.js"
 import usecasesOperationsControllers from "./Usecases/Operations.Controllers.js"
 
-export { usecasesHelloWorldControllers, usecasesMeControllers, usecasesOperationsControllers }
+export { usecasesBlogControllers, usecasesHelloWorldControllers, usecasesMeControllers, usecasesOperationsControllers }
 // codegen:end

--- a/_project/api/_src/Usecases/Blog.Controllers.ts
+++ b/_project/api/_src/Usecases/Blog.Controllers.ts
@@ -1,15 +1,19 @@
 import { BlogPost } from "@effect-app-boilerplate/models/Blog"
 import { BlogRsc } from "@effect-app-boilerplate/resources"
-
-const items: BlogPost[] = []
+import { BlogPostRepo } from "api/services.js"
 
 const blog = matchFor(BlogRsc)
+const GetPosts = blog.matchGetPosts(
+  { BlogPostRepo },
+  (_, { blogPostRepo }) => blogPostRepo.all.map((items) => ({ items }))
+)
 
-const GetPosts = blog.matchGetPosts({}, () => Effect({ items }))
-
-const CreatePost = blog.matchCreatePost({}, (req) =>
-  Effect(new BlogPost({ ...req }))
-    .tap((post) => Effect(items.push(post)))
-    .map((_) => _.id))
+const CreatePost = blog.matchCreatePost(
+  { BlogPostRepo },
+  (req, { blogPostRepo }) =>
+    Effect(new BlogPost({ ...req }))
+      .tap(blogPostRepo.save)
+      .map((_) => _.id)
+)
 
 export default blog.controllers({ GetPosts, CreatePost })

--- a/_project/api/_src/Usecases/Blog.Controllers.ts
+++ b/_project/api/_src/Usecases/Blog.Controllers.ts
@@ -3,6 +3,14 @@ import { BlogRsc } from "@effect-app-boilerplate/resources"
 import { BlogPostRepo } from "api/services.js"
 
 const blog = matchFor(BlogRsc)
+
+const FindPost = blog.matchFindPost(
+  { BlogPostRepo },
+  (req, { blogPostRepo }) =>
+    blogPostRepo
+      .find(req.id)
+      .map((_) => _.getOrNull)
+)
 const GetPosts = blog.matchGetPosts(
   { BlogPostRepo },
   (_, { blogPostRepo }) => blogPostRepo.all.map((items) => ({ items }))
@@ -16,4 +24,4 @@ const CreatePost = blog.matchCreatePost(
       .map((_) => _.id)
 )
 
-export default blog.controllers({ GetPosts, CreatePost })
+export default blog.controllers({ FindPost, GetPosts, CreatePost })

--- a/_project/api/_src/Usecases/Blog.Controllers.ts
+++ b/_project/api/_src/Usecases/Blog.Controllers.ts
@@ -64,8 +64,8 @@ const PublishPost = blog.matchPublishPost(
           // while operation is running...
           (_opId) =>
             Effect
-              .suspend(() => events.publish(new BogusEvent({})))
-              .schedule(Schedule.spaced(DUR.seconds(1)))
+              .suspend(() => events.publish(new BogusEvent()))
+              .schedule(Schedule.spaced(Duration.seconds(1)))
         )
       )
 

--- a/_project/api/_src/Usecases/Blog.Controllers.ts
+++ b/_project/api/_src/Usecases/Blog.Controllers.ts
@@ -2,7 +2,6 @@ import { BlogPost } from "@effect-app-boilerplate/models/Blog"
 import { BlogRsc } from "@effect-app-boilerplate/resources"
 import { BogusEvent } from "@effect-app-boilerplate/resources/Events"
 import { PositiveInt } from "@effect-app/prelude/schema"
-import { NotFoundError } from "api/errors.js"
 import { BlogPostRepo, Events, Operations } from "api/services.js"
 
 const blog = matchFor(BlogRsc)
@@ -31,11 +30,9 @@ const PublishPost = blog.matchPublishPost(
   { BlogPostRepo, Events, Operations },
   (req, { blogPostRepo, events, operations }) =>
     Do(($) => {
-      $(
-        blogPostRepo
-          .find(req.id)
-          .flatMap((_) => _.encaseInEffect(() => new NotFoundError("BlogPost", req.id)))
-      )
+      const post = $(blogPostRepo.get(req.id))
+
+      console.log("publishing post", post)
 
       const targets = [
         "google",
@@ -63,7 +60,7 @@ const PublishPost = blog.matchPublishPost(
                     )
                     .delay(Duration.seconds(4))
                 )
-                .map(() => "the answer to the universe is 41"),
+                .map(() => "the answer to the universe is 42"),
           // while operation is running...
           (_opId) =>
             Effect

--- a/_project/api/_src/Usecases/Blog.Controllers.ts
+++ b/_project/api/_src/Usecases/Blog.Controllers.ts
@@ -1,0 +1,15 @@
+import { BlogPost } from "@effect-app-boilerplate/models/Blog"
+import { BlogRsc } from "@effect-app-boilerplate/resources"
+
+const items: BlogPost[] = []
+
+const blog = matchFor(BlogRsc)
+
+const GetPosts = blog.matchGetPosts({}, () => Effect({ items }))
+
+const CreatePost = blog.matchCreatePost({}, (req) =>
+  Effect(new BlogPost({ ...req }))
+    .tap((post) => Effect(items.push(post)))
+    .map((_) => _.id))
+
+export default blog.controllers({ GetPosts, CreatePost })

--- a/_project/api/_src/Usecases/Graph.Controllers.ts
+++ b/_project/api/_src/Usecases/Graph.Controllers.ts
@@ -60,7 +60,7 @@ const Query = matchWithEffect("Query")(
       Effect.gen(function*($) {
         const handle = request(req, ctx)
         const r: GraphQueryResponse = yield* $(
-          Effect.all({
+          Effect.allPar({
             // TODO: AllMe currently has a temporal requirement; it must be executed first. (therefore atm requested first..)
             // for two reasons: 1. create the user if it didnt exist yet.
             // 2. because if the user changes locale, its stored on the user object, and put in cache for the follow-up handlers.
@@ -98,7 +98,7 @@ function mutation<Key extends string>(
         : x.isLeft()
         ? Effect(x)
         : (q?.query
-          ? Effect.all({
+          ? Effect.allPar({
             query: Query.flatMap(_ => _(q.query!, ctx)),
             result: resultQuery ? resultQuery(x.right, ctx) : emptyResponse
           }).map(({ query, result }) => ({ ...query, result })) // TODO: Replace $ variables in the query parameters baed on mutation output!
@@ -114,7 +114,7 @@ const Mutation = matchWithEffect("Mutation")(
       Effect.gen(function*($) {
         const handle = mutation(req, ctx)
         const r: GraphMutationResponse = yield* $(
-          Effect.all({
+          Effect.allPar({
             CreatePost: handle(
               "CreatePost",
               blogPostControllers.CreatePost.h,

--- a/_project/api/_src/Usecases/Graph.Controllers.ts
+++ b/_project/api/_src/Usecases/Graph.Controllers.ts
@@ -9,7 +9,7 @@ import { dropUndefined } from "@effect-app/core/utils"
 import { makeRequestId, RequestContext } from "@effect-app/infra/RequestContext"
 import { RequestContextContainer } from "@effect-app/infra/services/RequestContextContainer"
 import type { CTX } from "api/lib/routing.js"
-import { BlogControllers } from "./Blog.Controllers.js"
+import BlogControllers from "./Blog.Controllers.js"
 
 // TODO: Apply roles&rights to individual actions.
 
@@ -26,7 +26,7 @@ function request<Key extends string>(
     const q = req[name]
     return q
       ? Effect.gen(function*($) {
-        yield* $(RequestContextContainer.accessWithEffect(_ =>
+        yield* $(RequestContextContainer.flatMap(_ =>
           _.update(ctx =>
             RequestContext.inherit(ctx, {
               id: makeRequestId(),
@@ -47,10 +47,10 @@ function request<Key extends string>(
   }
 }
 
-const { controllers, matchWithEffect } = matchFor(GraphRsc)
+const graph = matchFor(GraphRsc)
 
 // TODO: Auto generate from the clients
-const Query = matchWithEffect("Query")(
+const Query = graph.matchQuery.withEffect(
   Effect.gen(function*($) {
     const blogPostControllers = yield* $(BlogControllers)
     return (req, ctx) =>
@@ -104,7 +104,7 @@ function mutation<Key extends string>(
   }
 }
 
-const Mutation = matchWithEffect("Mutation")(
+const Mutation = graph.matchMutation.withEffect(
   Effect.gen(function*($) {
     const blogPostControllers = yield* $(BlogControllers)
     return (req, ctx) =>
@@ -168,7 +168,7 @@ const Mutation = matchWithEffect("Mutation")(
 //   }
 // }
 
-export const GraphControllers = controllers({ Query, Mutation })
+export default graph.controllers({ Query, Mutation })
 
 // export const GraphControllers = Effect.struct({
 //   GraphQuery: match(GraphQuery, defaultErrorHandler, handleRequestEnv),

--- a/_project/api/_src/Usecases/Graph.Controllers.ts
+++ b/_project/api/_src/Usecases/Graph.Controllers.ts
@@ -1,0 +1,179 @@
+/**
+ * @experimental
+ */
+
+import { BasicRequestEnv } from "@effect-app-boilerplate/messages/RequestLayers"
+import { GraphRsc } from "@effect-app-boilerplate/resources"
+import type { GraphMutationResponse } from "@effect-app-boilerplate/resources/Graph/Mutation"
+import type { GraphQueryRequest, GraphQueryResponse } from "@effect-app-boilerplate/resources/Graph/Query"
+import { dropUndefined } from "@effect-app/core/utils"
+import { makeRequestId, RequestContext } from "@effect-app/infra/RequestContext"
+import { RequestContextContainer } from "@effect-app/infra/services/RequestContextContainer"
+import type { CTX } from "api/lib/routing.js"
+import { BlogControllers } from "./Blog.Controllers.js"
+
+// TODO: Apply roles&rights to individual actions.
+
+const NoResponse = Effect(undefined)
+
+function request<Key extends string>(
+  req: Partial<Record<Key, { input?: any } | undefined>>,
+  context: CTX
+) {
+  return <RKey extends Key, R, E, A>(
+    name: RKey,
+    handler: (inp: any, ctx: CTX) => Effect<R, E, A>
+  ) => {
+    const q = req[name]
+    return q
+      ? Effect.gen(function*($) {
+        yield* $(RequestContextContainer.accessWithEffect(_ =>
+          _.update(ctx =>
+            RequestContext.inherit(ctx, {
+              id: makeRequestId(),
+              locale: ctx.locale,
+              name: ReasonableString(name) // TODO: Use name from handler.Request
+            })
+          )
+        ))
+
+        const ctx = yield* $(RequestContextContainer.get)
+
+        const r = yield* $(
+          handler(q.input ?? {}, { ...context, context: ctx }).provideSomeContextEffect(
+            BasicRequestEnv
+          )
+        )
+        return r
+      })["|>"](Effect.either)
+      : NoResponse
+  }
+}
+
+const { controllers, matchWithEffect } = matchFor(GraphRsc)
+
+// TODO: Auto generate from the clients
+const Query = matchWithEffect("Query")(
+  Effect.gen(function*($) {
+    const blogPostControllers = yield* $(BlogControllers)
+    return (req, ctx) =>
+      Effect.gen(function*($) {
+        const handle = request(req, ctx)
+        const r: GraphQueryResponse = yield* $(
+          Effect.all({
+            // TODO: AllMe currently has a temporal requirement; it must be executed first. (therefore atm requested first..)
+            // for two reasons: 1. create the user if it didnt exist yet.
+            // 2. because if the user changes locale, its stored on the user object, and put in cache for the follow-up handlers.
+            // AllMe: handle("AllMe", AllMe.h),
+            // AllMeCommentActivity: handle("AllMeCommentActivity", AllMeCommentActivity.h),
+            // AllMeChangeRequests: handle("AllMeChangeRequests", AllMeChangeRequests.h),
+            // AllMeEventlog: handle("AllMeEventlog", AllMeEventlog.h),
+            // AllMeTasks: handle("AllMeTasks", AllMeTasks.h),
+
+            // FindPurchaseOrder: handle("FindPurchaseOrder", FindPurchaseOrder.h)
+            FindBlogPost: handle("FindBlogPost", blogPostControllers.FindPost.h)
+          })
+        )
+        return dropUndefined(r as any) // TODO: Fix optional encoder should ignore undefined values!
+      })
+  })
+)
+
+const emptyResponse = Effect(undefined)
+
+function mutation<Key extends string>(
+  req: Partial<Record<Key, { input?: any; query?: GraphQueryRequest } | undefined>>,
+  ctx: CTX
+) {
+  const f = request(req, ctx)
+  return <RKey extends Key, R, E, A, R2, E2, A2>(
+    name: RKey,
+    handler: (inp: any, ctx: CTX) => Effect<R, E, A>,
+    resultQuery?: (inp: A, ctx: CTX) => Effect<R2, E2, A2>
+  ) => {
+    const q = req[name]
+    return f(name, handler).flatMap(x =>
+      !x
+        ? Effect(x)
+        : x.isLeft()
+        ? Effect(x)
+        : (q?.query
+          ? Effect.all({
+            query: Query.flatMap(_ => _(q.query!, ctx)),
+            result: resultQuery ? resultQuery(x.right, ctx) : emptyResponse
+          }).map(({ query, result }) => ({ ...query, result })) // TODO: Replace $ variables in the query parameters baed on mutation output!
+          : emptyResponse).map(query => Either(query ? { query, response: x.right } : { response: x.right }))
+    )
+  }
+}
+
+const Mutation = matchWithEffect("Mutation")(
+  Effect.gen(function*($) {
+    const blogPostControllers = yield* $(BlogControllers)
+    return (req, ctx) =>
+      Effect.gen(function*($) {
+        const handle = mutation(req, ctx)
+        const r: GraphMutationResponse = yield* $(
+          Effect.all({
+            CreatePost: handle(
+              "CreatePost",
+              blogPostControllers.CreatePost.h,
+              (id, ctx) =>
+                blogPostControllers.FindPost.h({ id }, ctx)
+                  .flatMap(x => (!x ? Effect.die("Post went away?") : Effect(x)))
+            )
+            // UpdatePurchaseOrder: handle("UpdatePurchaseOrder", UpdatePurchaseOrder.h, () =>
+            //   FindPurchaseOrder.h(req.UpdatePurchaseOrder!.input).flatMap(x =>
+            //     !x ?
+            //       Effect.die("PO went away?") :
+            //       Effect(x)
+            //   ))
+          })
+        )
+        return dropUndefined(r as any) // TODO: Fix optional encoder should ignore undefined values!
+      })
+  })
+)
+
+// TODO: Implement for mutations, with optional query on return
+// function createAndRetrievePO() {
+//   const mutation = {
+//     "PurchaseOrders.Create": {
+//       input: { title: "dude" },
+//       // optional
+//       query: {
+//         "PurchaseOrders.Get": {
+//           input: {
+//             id: "$id" /* $ prefix means it should be taken from response output */,
+//           },
+//         },
+//       },
+//     },
+//   }
+//   type Response = {
+//     "PurchaseOrders.Create": Either<
+//       MutationError,
+//       {
+//         result: {
+//           id: "some id"
+//         }
+//         query: {
+//           "PurchaseOrders.Get": Either<
+//             QueryError,
+//             {
+//               id: "some id"
+//               title: "dude"
+//             }
+//           >
+//         }
+//       }
+//     >
+//   }
+// }
+
+export const GraphControllers = controllers({ Query, Mutation })
+
+// export const GraphControllers = Effect.struct({
+//   GraphQuery: match(GraphQuery, defaultErrorHandler, handleRequestEnv),
+//   GraphMutation: match(GraphMutation, defaultErrorHandler, handleRequestEnv)
+// })

--- a/_project/api/_src/Usecases/Graph.Controllers.ts
+++ b/_project/api/_src/Usecases/Graph.Controllers.ts
@@ -2,7 +2,6 @@
  * @experimental
  */
 
-import { BasicRequestEnv } from "@effect-app-boilerplate/messages/RequestLayers"
 import { GraphRsc } from "@effect-app-boilerplate/resources"
 import type { GraphMutationResponse } from "@effect-app-boilerplate/resources/Graph/Mutation"
 import type { GraphQueryRequest, GraphQueryResponse } from "@effect-app-boilerplate/resources/Graph/Query"
@@ -40,9 +39,7 @@ function request<Key extends string>(
         const ctx = yield* $(RequestContextContainer.get)
 
         const r = yield* $(
-          handler(q.input ?? {}, { ...context, context: ctx }).provideSomeContextEffect(
-            BasicRequestEnv
-          )
+          handler(q.input ?? {}, { ...context, context: ctx })
         )
         return r
       })["|>"](Effect.either)

--- a/_project/api/_src/api.ts
+++ b/_project/api/_src/api.ts
@@ -3,7 +3,7 @@ import { writeOpenapiDocs } from "@effect-app/infra/api/writeDocs"
 import type { ApiMainConfig } from "./config.js"
 import * as MW from "./middleware/index.js"
 import * as R from "./routes.js"
-import { Operations, StoreMaker, UserRepo } from "./services.js"
+import { BlogPostRepoLive, Operations, StoreMaker, UserRepo } from "./services.js"
 import { Events } from "./services/Events.js"
 
 const routes = Effect.all(R)
@@ -28,6 +28,7 @@ export function api(cfg: ApiMainConfig) {
     > logServerStart
 
   const services = Events.Live
+    > BlogPostRepoLive
     > StoreMaker.Live(Config(cfg.storage))
     > UserRepo.Live(
       cfg.fakeUsers === "sample" ? "sample" : ""

--- a/_project/api/_src/api.ts
+++ b/_project/api/_src/api.ts
@@ -3,7 +3,7 @@ import { writeOpenapiDocs } from "@effect-app/infra/api/writeDocs"
 import type { ApiMainConfig } from "./config.js"
 import * as MW from "./middleware/index.js"
 import * as R from "./routes.js"
-import { BlogPostRepoLive, Operations, StoreMaker, UserRepo } from "./services.js"
+import { BlogPostRepo, Operations, StoreMaker, UserRepo } from "./services.js"
 import { Events } from "./services/Events.js"
 
 const routes = Effect.all(R)
@@ -28,11 +28,11 @@ export function api(cfg: ApiMainConfig) {
     > logServerStart
 
   const services = Events.Live
-    > BlogPostRepoLive
     > StoreMaker.Live(Config(cfg.storage))
     > UserRepo.Live(
       cfg.fakeUsers === "sample" ? "sample" : ""
     )
+    > BlogPostRepo.Live("sample")
     > Operations.Live
     > Ex.LiveExpress(cfg.host, cfg.port)
 

--- a/_project/api/_src/services/DBContext.ts
+++ b/_project/api/_src/services/DBContext.ts
@@ -1,3 +1,4 @@
 // codegen:start {preset: barrel, include: ./DBContext/* }
+export * from "./DBContext/BlogPostRepo.js"
 export * from "./DBContext/UserRepo.js"
 // codegen:end

--- a/_project/api/_src/services/DBContext/BlogPostRepo.ts
+++ b/_project/api/_src/services/DBContext/BlogPostRepo.ts
@@ -1,0 +1,16 @@
+import type { BlogPost } from "@effect-ts-app/boilerplate-types/Blog"
+
+export interface BlogPostRepo {
+  all: Effect<never, never, readonly BlogPost[]>
+  save: (post: BlogPost) => Effect<never, never, void>
+}
+export const BlogPostRepo = Tag<BlogPostRepo>()
+
+export const BlogPostRepoLive = Layer(BlogPostRepo, () => {
+  const items: BlogPost[] = []
+
+  return {
+    all: Effect([...items]),
+    save: (post) => Effect(items.push(post))
+  }
+})

--- a/_project/api/_src/services/DBContext/BlogPostRepo.ts
+++ b/_project/api/_src/services/DBContext/BlogPostRepo.ts
@@ -1,7 +1,8 @@
-import type { BlogPost } from "@effect-ts-app/boilerplate-types/Blog"
+import type { BlogPost, BlogPostId } from "@effect-app-boilerplate/models/Blog"
 
 export interface BlogPostRepo {
   all: Effect<never, never, readonly BlogPost[]>
+  find: (id: BlogPostId) => Effect<never, never, Option<BlogPost>>
   save: (post: BlogPost) => Effect<never, never, void>
 }
 export const BlogPostRepo = Tag<BlogPostRepo>()
@@ -11,6 +12,7 @@ export const BlogPostRepoLive = Layer(BlogPostRepo, () => {
 
   return {
     all: Effect([...items]),
+    find: (id) => Effect(items.findFirst((_) => _.id === id)),
     save: (post) => Effect(items.push(post))
   }
 })

--- a/_project/api/_src/services/DBContext/BlogPostRepo.ts
+++ b/_project/api/_src/services/DBContext/BlogPostRepo.ts
@@ -1,4 +1,4 @@
-import type { BlogPost, BlogPostId } from "@effect-app-boilerplate/models/Blog"
+import { BlogPost, BlogPostId } from "@effect-app-boilerplate/models/Blog"
 
 export interface BlogPostRepo {
   all: Effect<never, never, readonly BlogPost[]>
@@ -8,7 +8,13 @@ export interface BlogPostRepo {
 export const BlogPostRepo = Tag<BlogPostRepo>()
 
 export const BlogPostRepoLive = Layer(BlogPostRepo, () => {
-  const items: BlogPost[] = []
+  const items: BlogPost[] = [
+    new BlogPost({
+      id: BlogPostId("post-test123"),
+      title: ReasonableString("Test post"),
+      body: LongString("imma test body")
+    })
+  ]
 
   return {
     all: Effect([...items]),

--- a/_project/api/openapi.json
+++ b/_project/api/openapi.json
@@ -83,6 +83,39 @@
         }
       }
     },
+    "/blog/posts/{id}": {
+      "get": {
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "minLength": 6,
+              "maxLength": 50,
+              "title": "BlogPostId",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BlogPost",
+                  "nullable": true
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "ValidationError"
+          }
+        }
+      }
+    },
     "/hello-world": {
       "get": {
         "parameters": [],

--- a/_project/api/openapi.json
+++ b/_project/api/openapi.json
@@ -160,6 +160,173 @@
         }
       }
     },
+    "/graph/mutate": {
+      "post": {
+        "operationId": "GraphMutationRequest",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "CreatePost": {
+                    "properties": {
+                      "input": {
+                        "properties": {
+                          "title": {
+                            "minLength": 1,
+                            "maxLength": 255,
+                            "type": "string"
+                          },
+                          "body": {
+                            "minLength": 1,
+                            "maxLength": 2047,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "title",
+                          "body"
+                        ],
+                        "type": "object"
+                      },
+                      "query": {
+                        "properties": {
+                          "FindBlogPost": {
+                            "properties": {
+                              "input": {
+                                "properties": {
+                                  "id": {
+                                    "minLength": 6,
+                                    "maxLength": 50,
+                                    "title": "BlogPostId",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "id"
+                                ],
+                                "type": "object"
+                              }
+                            },
+                            "required": [
+                              "input"
+                            ],
+                            "type": "object"
+                          },
+                          "GetAllBlogPosts": {
+                            "properties": {
+                              "input": {
+                                "properties": {},
+                                "type": "object"
+                              }
+                            },
+                            "required": [
+                              "input"
+                            ],
+                            "type": "object"
+                          },
+                          "result": {
+                            "type": "boolean"
+                          }
+                        },
+                        "type": "object"
+                      }
+                    },
+                    "required": [
+                      "input"
+                    ],
+                    "type": "object"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GraphMutationResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "ValidationError"
+          }
+        }
+      }
+    },
+    "/graph/query": {
+      "post": {
+        "operationId": "GraphQueryRequest",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "FindBlogPost": {
+                    "properties": {
+                      "input": {
+                        "properties": {
+                          "id": {
+                            "minLength": 6,
+                            "maxLength": 50,
+                            "title": "BlogPostId",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id"
+                        ],
+                        "type": "object"
+                      }
+                    },
+                    "required": [
+                      "input"
+                    ],
+                    "type": "object"
+                  },
+                  "GetAllBlogPosts": {
+                    "properties": {
+                      "input": {
+                        "properties": {},
+                        "type": "object"
+                      }
+                    },
+                    "required": [
+                      "input"
+                    ],
+                    "type": "object"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GraphQueryResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "ValidationError"
+          }
+        }
+      }
+    },
     "/hello-world": {
       "get": {
         "parameters": [],
@@ -319,6 +486,337 @@
           "body",
           "createdAt"
         ],
+        "type": "object"
+      },
+      "InvalidStateError": {
+        "title": "InvalidStateError",
+        "properties": {
+          "_tag": {
+            "enum": [
+              "InvalidStateError"
+            ],
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "_tag",
+          "message"
+        ],
+        "type": "object"
+      },
+      "OptimisticConcurrencyException": {
+        "title": "OptimisticConcurrencyException",
+        "properties": {
+          "_tag": {
+            "enum": [
+              "OptimisticConcurrencyException"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "_tag"
+        ],
+        "type": "object"
+      },
+      "NotFoundError": {
+        "title": "NotFoundError",
+        "properties": {
+          "_tag": {
+            "enum": [
+              "NotFoundError"
+            ],
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "_tag",
+          "message"
+        ],
+        "type": "object"
+      },
+      "NotLoggedInError": {
+        "title": "NotLoggedInError",
+        "properties": {
+          "_tag": {
+            "enum": [
+              "NotLoggedInError"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "_tag"
+        ],
+        "type": "object"
+      },
+      "UnauthorizedError": {
+        "title": "UnauthorizedError",
+        "properties": {
+          "_tag": {
+            "enum": [
+              "UnauthorizedError"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "_tag"
+        ],
+        "type": "object"
+      },
+      "ValidationError": {
+        "title": "ValidationError",
+        "properties": {
+          "_tag": {
+            "enum": [
+              "ValidationError"
+            ],
+            "type": "string"
+          },
+          "errors": {
+            "items": {
+              "properties": {},
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "_tag",
+          "errors"
+        ],
+        "type": "object"
+      },
+      "GraphMutationResponse": {
+        "title": "GraphMutationResponse",
+        "properties": {
+          "CreatePost": {
+            "oneOf": [
+              {
+                "properties": {
+                  "_tag": {
+                    "enum": [
+                      "Left"
+                    ]
+                  },
+                  "left": {
+                    "title": "SupportedErrors",
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/InvalidStateError"
+                      },
+                      {
+                        "$ref": "#/components/schemas/OptimisticConcurrencyException"
+                      },
+                      {
+                        "$ref": "#/components/schemas/NotFoundError"
+                      },
+                      {
+                        "$ref": "#/components/schemas/NotLoggedInError"
+                      },
+                      {
+                        "$ref": "#/components/schemas/UnauthorizedError"
+                      },
+                      {
+                        "$ref": "#/components/schemas/ValidationError"
+                      }
+                    ],
+                    "discriminator": {
+                      "propertyName": "_tag"
+                    }
+                  }
+                },
+                "required": [
+                  "_tag",
+                  "left"
+                ],
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "_tag": {
+                    "enum": [
+                      "Right"
+                    ]
+                  },
+                  "right": {
+                    "properties": {
+                      "response": {
+                        "minLength": 6,
+                        "maxLength": 50,
+                        "title": "BlogPostId",
+                        "type": "string"
+                      },
+                      "query": {
+                        "properties": {
+                          "FindBlogPost": {
+                            "oneOf": [
+                              {
+                                "properties": {
+                                  "_tag": {
+                                    "enum": [
+                                      "Left"
+                                    ]
+                                  },
+                                  "left": {
+                                    "title": "SupportedErrors",
+                                    "oneOf": [
+                                      {
+                                        "$ref": "#/components/schemas/InvalidStateError"
+                                      },
+                                      {
+                                        "$ref": "#/components/schemas/OptimisticConcurrencyException"
+                                      },
+                                      {
+                                        "$ref": "#/components/schemas/NotFoundError"
+                                      },
+                                      {
+                                        "$ref": "#/components/schemas/NotLoggedInError"
+                                      },
+                                      {
+                                        "$ref": "#/components/schemas/UnauthorizedError"
+                                      },
+                                      {
+                                        "$ref": "#/components/schemas/ValidationError"
+                                      }
+                                    ],
+                                    "discriminator": {
+                                      "propertyName": "_tag"
+                                    }
+                                  }
+                                },
+                                "required": [
+                                  "_tag",
+                                  "left"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "properties": {
+                                  "_tag": {
+                                    "enum": [
+                                      "Right"
+                                    ]
+                                  },
+                                  "right": {
+                                    "$ref": "#/components/schemas/BlogPost",
+                                    "nullable": true
+                                  }
+                                },
+                                "required": [
+                                  "_tag",
+                                  "right"
+                                ],
+                                "type": "object"
+                              }
+                            ],
+                            "discriminator": {
+                              "propertyName": "_tag"
+                            }
+                          },
+                          "result": {
+                            "$ref": "#/components/schemas/BlogPost"
+                          }
+                        },
+                        "type": "object"
+                      }
+                    },
+                    "required": [
+                      "response"
+                    ],
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "_tag",
+                  "right"
+                ],
+                "type": "object"
+              }
+            ],
+            "discriminator": {
+              "propertyName": "_tag"
+            }
+          }
+        },
+        "type": "object"
+      },
+      "GraphQueryResponse": {
+        "title": "GraphQueryResponse",
+        "properties": {
+          "FindBlogPost": {
+            "oneOf": [
+              {
+                "properties": {
+                  "_tag": {
+                    "enum": [
+                      "Left"
+                    ]
+                  },
+                  "left": {
+                    "title": "SupportedErrors",
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/InvalidStateError"
+                      },
+                      {
+                        "$ref": "#/components/schemas/OptimisticConcurrencyException"
+                      },
+                      {
+                        "$ref": "#/components/schemas/NotFoundError"
+                      },
+                      {
+                        "$ref": "#/components/schemas/NotLoggedInError"
+                      },
+                      {
+                        "$ref": "#/components/schemas/UnauthorizedError"
+                      },
+                      {
+                        "$ref": "#/components/schemas/ValidationError"
+                      }
+                    ],
+                    "discriminator": {
+                      "propertyName": "_tag"
+                    }
+                  }
+                },
+                "required": [
+                  "_tag",
+                  "left"
+                ],
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "_tag": {
+                    "enum": [
+                      "Right"
+                    ]
+                  },
+                  "right": {
+                    "$ref": "#/components/schemas/BlogPost",
+                    "nullable": true
+                  }
+                },
+                "required": [
+                  "_tag",
+                  "right"
+                ],
+                "type": "object"
+              }
+            ],
+            "discriminator": {
+              "propertyName": "_tag"
+            }
+          }
+        },
         "type": "object"
       },
       "User": {

--- a/_project/api/openapi.json
+++ b/_project/api/openapi.json
@@ -116,6 +116,50 @@
         }
       }
     },
+    "/blog/posts/{id}/publish": {
+      "post": {
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "minLength": 6,
+              "maxLength": 50,
+              "title": "BlogPostId",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {},
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "minLength": 6,
+                  "maxLength": 50,
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "ValidationError"
+          }
+        }
+      }
+    },
     "/hello-world": {
       "get": {
         "parameters": [],

--- a/_project/api/openapi.json
+++ b/_project/api/openapi.json
@@ -6,6 +6,83 @@
   },
   "tags": [],
   "paths": {
+    "/blog/posts": {
+      "post": {
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "title": {
+                    "minLength": 1,
+                    "maxLength": 255,
+                    "type": "string"
+                  },
+                  "body": {
+                    "minLength": 1,
+                    "maxLength": 2047,
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "title",
+                  "body"
+                ],
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "minLength": 6,
+                  "maxLength": 50,
+                  "title": "BlogPostId",
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "ValidationError"
+          }
+        }
+      },
+      "get": {
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "items": {
+                      "items": {
+                        "$ref": "#/components/schemas/BlogPost"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "items"
+                  ],
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "ValidationError"
+          }
+        }
+      }
+    },
     "/hello-world": {
       "get": {
         "parameters": [],
@@ -135,6 +212,38 @@
       }
     },
     "schemas": {
+      "BlogPost": {
+        "title": "BlogPost",
+        "properties": {
+          "id": {
+            "minLength": 6,
+            "maxLength": 50,
+            "title": "BlogPostId",
+            "type": "string"
+          },
+          "title": {
+            "minLength": 1,
+            "maxLength": 255,
+            "type": "string"
+          },
+          "body": {
+            "minLength": 1,
+            "maxLength": 2047,
+            "type": "string"
+          },
+          "createdAt": {
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "title",
+          "body",
+          "createdAt"
+        ],
+        "type": "object"
+      },
       "User": {
         "title": "User",
         "properties": {

--- a/_project/frontend-nuxt/layouts/default.vue
+++ b/_project/frontend-nuxt/layouts/default.vue
@@ -31,6 +31,8 @@ onMounted(() => {
         <NuxtLink :to="{ name: 'index' }"
           ><img :alt="appConfig.title" src="/img/logo.png" width="110"
         /></NuxtLink>
+        |
+        <NuxtLink :to="{ name: 'blog' }">Blog</NuxtLink>
       </v-app-bar-title>
 
       <div>{{ router.currentRoute.value.name }}</div>

--- a/_project/frontend-nuxt/pages/blog.vue
+++ b/_project/frontend-nuxt/pages/blog.vue
@@ -3,8 +3,10 @@ import { BlogRsc } from "@effect-app-boilerplate/resources"
 
 const blogClient = clientFor(BlogRsc)
 
-const [, createPost] = useMutation(blogClient.createPost)
-const [, latestPosts] = useSafeQuery(blogClient.getPosts)
+const [, createPost_] = useMutation(blogClient.createPost)
+const [, latestPosts, reloadPosts] = useSafeQuery(blogClient.getPosts)
+
+const createPost = flow(createPost_, _ => _.then(_ => reloadPosts()))
 </script>
 
 <template>

--- a/_project/frontend-nuxt/pages/blog.vue
+++ b/_project/frontend-nuxt/pages/blog.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+import { BlogRsc } from "@effect-app-boilerplate/resources"
+
+const blogClient = clientFor(BlogRsc)
+
+const [, createPost] = useMutation(blogClient.createPost)
+const [, latestPosts] = useSafeQuery(blogClient.getPosts)
+</script>
+
+<template>
+  <div>
+    Here's a Post List
+
+    <ul v-if="latestPosts">
+      <li v-for="post in latestPosts.items" :key="post.id">
+        {{ post.title }}
+      </li>
+    </ul>
+
+    <div>
+      a new Title and a new body
+      <v-btn
+        @click="
+          createPost({
+            title: MO.ReasonableString('empty'),
+            body: MO.LongString('A body'),
+          })
+        "
+      >
+        Create new post
+        </v-btn>
+    </div>
+  </div>
+</template>

--- a/_project/frontend-nuxt/pages/blog/[id].vue
+++ b/_project/frontend-nuxt/pages/blog/[id].vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { BlogRsc } from "@effect-app-boilerplate/resources"
+import type { ClientEvents } from "@effect-app-boilerplate/resources"
 import { BlogPostId } from "@effect-app-boilerplate/models/Blog"
 
 const { id } = useRouteParams({ id: BlogPostId })
@@ -7,6 +8,18 @@ const { id } = useRouteParams({ id: BlogPostId })
 const blogClient = clientFor(BlogRsc)
 const [, latestPost, reloadPost] = useSafeQueryWithArg(blogClient.findPost, {
   id,
+})
+
+const bogusOutput = ref<ClientEvents>()
+
+onMountedWithCleanup(() => {
+  const callback = (_: ClientEvents) => {
+    bogusOutput.value = _
+  }
+  bus.on("serverEvents", callback)
+  return () => {
+    bus.off("serverEvents", callback)
+  }
 })
 
 const progress = ref("")
@@ -23,6 +36,9 @@ const [publishing, publish] = useAndHandleMutation(
 </script>
 
 <template>
+  <div v-if="bogusOutput">
+    The latest bogus event is: {{ bogusOutput.id }} at {{ bogusOutput.at }}
+  </div>
   <div v-if="latestPost">
     <v-btn @click="publish({ id })" :disabled="publishing.loading">
       Publish to all blog sites {{ publishing.loading ? `(${progress})` : "" }}

--- a/_project/frontend-nuxt/pages/blog/[id].vue
+++ b/_project/frontend-nuxt/pages/blog/[id].vue
@@ -5,11 +5,28 @@ import { BlogPostId } from "@effect-app-boilerplate/models/Blog"
 const { id } = useRouteParams({ id: BlogPostId })
 
 const blogClient = clientFor(BlogRsc)
-const [, latestPost] = useSafeQueryWithArg(blogClient.findPost, { id })
+const [, latestPost, reloadPost] = useSafeQueryWithArg(blogClient.findPost, {
+  id,
+})
+
+const progress = ref("")
+const [publishing, publish] = useAndHandleMutation(
+  refreshAndWaitForOperation(
+    blogClient.publishPost,
+    Effect.promise(() => reloadPost()),
+    op => {
+      progress.value = `${op.progress?.completed}/${op.progress?.total}`
+    }
+  ),
+  "Publish Blog Post"
+)
 </script>
 
 <template>
   <div v-if="latestPost">
+    <v-btn @click="publish({ id })" :disabled="publishing.loading">
+      Publish to all blog sites {{ publishing.loading ? `(${progress})` : "" }}
+    </v-btn>
     <div>Title: {{ latestPost.title }}</div>
     <div>Body: {{ latestPost.body }}</div>
   </div>

--- a/_project/frontend-nuxt/pages/blog/[id].vue
+++ b/_project/frontend-nuxt/pages/blog/[id].vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+import { BlogRsc } from "@effect-app-boilerplate/resources"
+import { BlogPostId } from "@effect-app-boilerplate/models/Blog"
+
+const { id } = useRouteParams({ id: BlogPostId })
+
+const blogClient = clientFor(BlogRsc)
+const [, latestPost] = useSafeQueryWithArg(blogClient.findPost, { id })
+</script>
+
+<template>
+  <div v-if="latestPost">
+    <div>Title: {{ latestPost.title }}</div>
+    <div>Body: {{ latestPost.body }}</div>
+  </div>
+</template>

--- a/_project/frontend-nuxt/pages/blog/index.vue
+++ b/_project/frontend-nuxt/pages/blog/index.vue
@@ -11,14 +11,6 @@ const createPost = flow(createPost_, _ => _.then(_ => reloadPosts()))
 
 <template>
   <div>
-    Here's a Post List
-
-    <ul v-if="latestPosts">
-      <li v-for="post in latestPosts.items" :key="post.id">
-        {{ post.title }}
-      </li>
-    </ul>
-
     <div>
       a new Title and a new body
       <v-btn
@@ -32,5 +24,13 @@ const createPost = flow(createPost_, _ => _.then(_ => reloadPosts()))
         Create new post
         </v-btn>
     </div>
+    Here's a Post List
+    <ul v-if="latestPosts">
+      <li v-for="post in latestPosts.items" :key="post.id">
+        <nuxt-link :to="{ name: 'blog-id', params: { id: post.id } }">{{
+          post.title
+        }}</nuxt-link>
+      </li>
+    </ul>
   </div>
 </template>

--- a/_project/models/_src/Blog.ts
+++ b/_project/models/_src/Blog.ts
@@ -1,0 +1,32 @@
+import { prefixedStringId } from "@effect-app/prelude/schema"
+
+export const BlogPostId = prefixedStringId<BlogPostId>()("post", "BlogPostId")
+export interface BlogPostIdBrand {
+  readonly BlogPostId: unique symbol
+}
+export type BlogPostId = StringId & BlogPostIdBrand & `post-${string}`
+
+@useClassFeaturesForSchema
+export class BlogPost extends MNModel<BlogPost, BlogPost.ConstructorInput, BlogPost.Encoded, BlogPost.Props>()({
+  id: BlogPostId.withDefault,
+  title: ReasonableString,
+  body: LongString,
+  createdAt: date.withDefault
+}) {}
+
+// codegen:start {preset: model}
+//
+/* eslint-disable */
+export namespace BlogPost {
+  /**
+   * @tsplus type BlogPost.Encoded
+   * @tsplus companion BlogPost.Encoded/Ops
+   */
+  export class Encoded extends EncodedClass<typeof BlogPost>() {}
+  export interface ConstructorInput
+    extends ConstructorInputFromApi<typeof BlogPost> {}
+  export interface Props extends GetProvidedProps<typeof BlogPost> {}
+}
+/* eslint-enable */
+//
+// codegen:end

--- a/_project/models/package.json
+++ b/_project/models/package.json
@@ -24,6 +24,16 @@
     }
   },
   "exports": {
+    "./Blog": {
+      "import": {
+        "types": "./dist/Blog.d.ts",
+        "default": "./dist/Blog.js"
+      },
+      "require": {
+        "types": "./dist/Blog.d.ts",
+        "default": "./_cjs/Blog.cjs"
+      }
+    },
     "./User": {
       "import": {
         "types": "./dist/User.d.ts",

--- a/_project/resources/_src/Blog.ts
+++ b/_project/resources/_src/Blog.ts
@@ -1,4 +1,5 @@
 // codegen:start {preset: barrel, include: ./Blog/*.ts, export: { as: 'PascalCase' }, nodir: false }
 export * as CreatePost from "./Blog/CreatePost.js"
+export * as FindPost from "./Blog/FindPost.js"
 export * as GetPosts from "./Blog/GetPosts.js"
 // codegen:end

--- a/_project/resources/_src/Blog.ts
+++ b/_project/resources/_src/Blog.ts
@@ -1,0 +1,4 @@
+// codegen:start {preset: barrel, include: ./Blog/*.ts, export: { as: 'PascalCase' }, nodir: false }
+export * as CreatePost from "./Blog/CreatePost.js"
+export * as GetPosts from "./Blog/GetPosts.js"
+// codegen:end

--- a/_project/resources/_src/Blog.ts
+++ b/_project/resources/_src/Blog.ts
@@ -2,4 +2,5 @@
 export * as CreatePost from "./Blog/CreatePost.js"
 export * as FindPost from "./Blog/FindPost.js"
 export * as GetPosts from "./Blog/GetPosts.js"
+export * as PublishPost from "./Blog/PublishPost.js"
 // codegen:end

--- a/_project/resources/_src/Blog/CreatePost.ts
+++ b/_project/resources/_src/Blog/CreatePost.ts
@@ -1,5 +1,7 @@
 import { BlogPost, BlogPostId } from "@effect-app-boilerplate/models/Blog"
 
+@allowAnonymous
+@allowRoles("user")
 export class CreatePostRequest extends Post("/blog/posts")<CreatePostRequest>()(
   BlogPost.pick("title", "body")
 ) {}

--- a/_project/resources/_src/Blog/CreatePost.ts
+++ b/_project/resources/_src/Blog/CreatePost.ts
@@ -1,0 +1,7 @@
+import { BlogPost, BlogPostId } from "@effect-app-boilerplate/models/Blog"
+
+export class CreatePostRequest extends Post("/blog/posts")<CreatePostRequest>()(
+  BlogPost.pick("title", "body")
+) {}
+
+export const CreatePostResponse = BlogPostId

--- a/_project/resources/_src/Blog/FindPost.ts
+++ b/_project/resources/_src/Blog/FindPost.ts
@@ -1,0 +1,9 @@
+import { BlogPost, BlogPostId } from "@effect-app-boilerplate/models/Blog"
+
+@allowAnonymous
+@allowRoles("user")
+export class FindPostRequest extends Get("/blog/posts/:id")<FindPostRequest>()({
+  id: BlogPostId
+}) {}
+
+export const FindPostResponse = nullable(BlogPost)

--- a/_project/resources/_src/Blog/GetPosts.ts
+++ b/_project/resources/_src/Blog/GetPosts.ts
@@ -1,5 +1,7 @@
 import { BlogPost } from "@effect-app-boilerplate/models/Blog"
 
+@allowAnonymous
+@allowRoles("user")
 export class GetPostsRequest extends Get("/blog/posts")<GetPostsRequest>()(
   {}
 ) {}

--- a/_project/resources/_src/Blog/GetPosts.ts
+++ b/_project/resources/_src/Blog/GetPosts.ts
@@ -1,0 +1,9 @@
+import { BlogPost } from "@effect-app-boilerplate/models/Blog"
+
+export class GetPostsRequest extends Get("/blog/posts")<GetPostsRequest>()(
+  {}
+) {}
+
+export class GetPostsResponse extends Model<GetPostsResponse>()({
+  items: array(BlogPost)
+}) {}

--- a/_project/resources/_src/Blog/PublishPost.ts
+++ b/_project/resources/_src/Blog/PublishPost.ts
@@ -1,0 +1,10 @@
+import { BlogPostId } from "@effect-app-boilerplate/models/Blog"
+import { OperationId } from "../Views.js"
+
+@allowAnonymous
+@allowRoles("user")
+export class PublishPostRequest extends Post("/blog/posts/:id/publish")<PublishPostRequest>()({
+  id: BlogPostId
+}) {}
+
+export const PublishPostResponse = OperationId

--- a/_project/resources/_src/Graph.ts
+++ b/_project/resources/_src/Graph.ts
@@ -1,0 +1,4 @@
+// codegen:start {preset: barrel, include: ./Graph/*.ts, export: { as: 'PascalCase' }, exclude: "./Graph/utils.ts", nodir: false }
+export * as Mutation from "./Graph/Mutation.js"
+export * as Query from "./Graph/Query.js"
+// codegen:end

--- a/_project/resources/_src/Graph/Mutation.ts
+++ b/_project/resources/_src/Graph/Mutation.ts
@@ -9,7 +9,7 @@ const makeMutationInput_ = makeMutationInput(GraphQueryRequest.Api.props)
 
 // TODO: Add The follow-up Graph Query
 // - parse inputs, when string and starts with $, take from mutation output.
-@useClassNameForSchema
+@useClassFeaturesForSchema
 @allowAnonymous
 @allowRoles("user")
 export class GraphMutationRequest extends Post("/graph/mutate")<GraphMutationRequest>()(
@@ -28,7 +28,7 @@ const PostResult = props({
   result: optProp(BlogPost)
 })
 
-@useClassNameForSchema
+@useClassFeaturesForSchema
 export class GraphMutationResponse extends Model<GraphMutationResponse>()({
   // TODO: Support guaranteed optional sub-queries, like on Create/Update of PO
   // guarantee an optional return of PurchaseOrder

--- a/_project/resources/_src/Graph/Mutation.ts
+++ b/_project/resources/_src/Graph/Mutation.ts
@@ -1,0 +1,54 @@
+import { BlogPost } from "@effect-app-boilerplate/models/Blog"
+import { either } from "@effect-app/prelude/schema"
+import { CreatePost } from "../Blog.js"
+import { MutationErrors } from "../errors.js"
+import { GraphQueryRequest, GraphQueryResponse } from "./Query.js"
+import { makeMutationInput } from "./utils.js"
+
+const makeMutationInput_ = makeMutationInput(GraphQueryRequest.Api.props)
+
+// TODO: Add The follow-up Graph Query
+// - parse inputs, when string and starts with $, take from mutation output.
+@useClassNameForSchema
+@allowAnonymous
+@allowRoles("user")
+export class GraphMutationRequest extends Post("/graph/mutate")<GraphMutationRequest>()(
+  {
+    CreatePost: optProp(
+      makeMutationInput_(CreatePost.CreatePostRequest)
+    )
+    // UpdatePurchaseOrder: optProp(
+    //   makeMutationInput_(PurchaseOrders.Update.UpdatePurchaseOrderRequest)
+    // )
+  }
+) {}
+
+const PostResult = props({
+  ...GraphQueryResponse.Api.props,
+  result: optProp(BlogPost)
+})
+
+@useClassNameForSchema
+export class GraphMutationResponse extends Model<GraphMutationResponse>()({
+  // TODO: Support guaranteed optional sub-queries, like on Create/Update of PO
+  // guarantee an optional return of PurchaseOrder
+  // first must enable PO cache for guarantee.
+  CreatePost: optProp(
+    either(
+      MutationErrors,
+      props({
+        response: prop(CreatePost.CreatePostResponse),
+        query: optProp(PostResult)
+      })
+    )
+  )
+  // UpdatePurchaseOrder: optProp(
+  //   either(
+  //     MutationErrors,
+  //     props({
+  //       response: optProp(Void),
+  //       query: optProp(POResult)
+  //     })
+  //   )
+  // )
+}) {}

--- a/_project/resources/_src/Graph/Mutation.ts
+++ b/_project/resources/_src/Graph/Mutation.ts
@@ -14,9 +14,8 @@ const makeMutationInput_ = makeMutationInput(GraphQueryRequest.Api.props)
 @allowRoles("user")
 export class GraphMutationRequest extends Post("/graph/mutate")<GraphMutationRequest>()(
   {
-    CreatePost: optProp(
-      makeMutationInput_(CreatePost.CreatePostRequest)
-    )
+    CreatePost: makeMutationInput_(CreatePost.CreatePostRequest)
+      .optional
     // UpdatePurchaseOrder: optProp(
     //   makeMutationInput_(PurchaseOrders.Update.UpdatePurchaseOrderRequest)
     // )
@@ -25,7 +24,7 @@ export class GraphMutationRequest extends Post("/graph/mutate")<GraphMutationReq
 
 const PostResult = props({
   ...GraphQueryResponse.Api.props,
-  result: optProp(BlogPost)
+  result: BlogPost.optional
 })
 
 @useClassFeaturesForSchema
@@ -33,21 +32,20 @@ export class GraphMutationResponse extends Model<GraphMutationResponse>()({
   // TODO: Support guaranteed optional sub-queries, like on Create/Update of PO
   // guarantee an optional return of PurchaseOrder
   // first must enable PO cache for guarantee.
-  CreatePost: optProp(
-    either(
-      MutationErrors,
-      props({
-        response: prop(CreatePost.CreatePostResponse),
-        query: optProp(PostResult)
-      })
-    )
+  CreatePost: either(
+    MutationErrors,
+    props({
+      response: CreatePost.CreatePostResponse,
+      query: PostResult.optional
+    })
   )
+    .optional
   // UpdatePurchaseOrder: optProp(
   //   either(
   //     MutationErrors,
   //     props({
-  //       response: optProp(Void),
-  //       query: optProp(POResult)
+  //       response: Void.optional,
+  //       query: POResult.optional
   //     })
   //   )
   // )

--- a/_project/resources/_src/Graph/Query.ts
+++ b/_project/resources/_src/Graph/Query.ts
@@ -1,0 +1,39 @@
+import { either } from "@effect-app/prelude/schema"
+import { QueryErrors } from "../errors.js"
+import { BlogRsc } from "../index.js"
+import { makeInput } from "./utils.js"
+
+@useClassNameForSchema
+@allowAnonymous
+@allowRoles("user")
+export class GraphQueryRequest extends Post("/graph/query")<GraphQueryRequest>()({
+  // AllMe: optProp(makeInput(Me.All.GetMeRequest, true)),
+  // AllMeEventlog: optProp(makeInput(Me.Eventlog.AllMeEventlogRequest, true)),
+  // AllMeChangeRequests: optProp(
+  //   makeInput(Me.ChangeRequests.AllMeChangeRequestsRequest, true)
+  // ),
+  // AllMeCommentActivity: optProp(
+  //   makeInput(Me.CommentActivity.AllMeCommentActivityRequest, true)
+  // ),
+  // AllMeTasks: optProp(makeInput(Me.Tasks.AllMeTasksRequest, true)),
+
+  FindBlogPost: optProp(makeInput(BlogRsc.FindPost.FindPostRequest)),
+  GetAllBlogPosts: optProp(makeInput(BlogRsc.GetPosts.GetPostsRequest))
+}) {}
+
+@useClassNameForSchema
+export class GraphQueryResponse extends Model<GraphQueryResponse>()({
+  // AllMe: optProp(either(QueryErrors, Me.All.GetMeResponse)),
+  // AllMeEventlog: optProp(either(QueryErrors, Me.Eventlog.AllMeEventlogResponse)),
+  // AllMeChangeRequests: optProp(
+  //   either(QueryErrors, Me.ChangeRequests.AllMeChangeRequestsResponse)
+  // ),
+  // AllMeCommentActivity: optProp(
+  //   either(QueryErrors, Me.CommentActivity.AllMeCommentActivityResponse)
+  // ),
+  // AllMeTasks: optProp(either(QueryErrors, Me.Tasks.AllMeTasksResponse)),
+
+  FindBlogPost: optProp(
+    either(QueryErrors, BlogRsc.FindPost.FindPostResponse)
+  )
+}) {}

--- a/_project/resources/_src/Graph/Query.ts
+++ b/_project/resources/_src/Graph/Query.ts
@@ -3,7 +3,7 @@ import { QueryErrors } from "../errors.js"
 import { BlogRsc } from "../index.js"
 import { makeInput } from "./utils.js"
 
-@useClassNameForSchema
+@useClassFeaturesForSchema
 @allowAnonymous
 @allowRoles("user")
 export class GraphQueryRequest extends Post("/graph/query")<GraphQueryRequest>()({
@@ -21,7 +21,7 @@ export class GraphQueryRequest extends Post("/graph/query")<GraphQueryRequest>()
   GetAllBlogPosts: optProp(makeInput(BlogRsc.GetPosts.GetPostsRequest))
 }) {}
 
-@useClassNameForSchema
+@useClassFeaturesForSchema
 export class GraphQueryResponse extends Model<GraphQueryResponse>()({
   // AllMe: optProp(either(QueryErrors, Me.All.GetMeResponse)),
   // AllMeEventlog: optProp(either(QueryErrors, Me.Eventlog.AllMeEventlogResponse)),

--- a/_project/resources/_src/Graph/Query.ts
+++ b/_project/resources/_src/Graph/Query.ts
@@ -1,6 +1,6 @@
 import { either } from "@effect-app/prelude/schema"
+import * as BlogRsc from "../Blog.js"
 import { QueryErrors } from "../errors.js"
-import { BlogRsc } from "../index.js"
 import { makeInput } from "./utils.js"
 
 @useClassFeaturesForSchema
@@ -17,8 +17,8 @@ export class GraphQueryRequest extends Post("/graph/query")<GraphQueryRequest>()
   // ),
   // AllMeTasks: optProp(makeInput(Me.Tasks.AllMeTasksRequest, true)),
 
-  FindBlogPost: optProp(makeInput(BlogRsc.FindPost.FindPostRequest)),
-  GetAllBlogPosts: optProp(makeInput(BlogRsc.GetPosts.GetPostsRequest))
+  FindBlogPost: makeInput(BlogRsc.FindPost.FindPostRequest).optional,
+  GetAllBlogPosts: makeInput(BlogRsc.GetPosts.GetPostsRequest).optional
 }) {}
 
 @useClassFeaturesForSchema
@@ -33,7 +33,5 @@ export class GraphQueryResponse extends Model<GraphQueryResponse>()({
   // ),
   // AllMeTasks: optProp(either(QueryErrors, Me.Tasks.AllMeTasksResponse)),
 
-  FindBlogPost: optProp(
-    either(QueryErrors, BlogRsc.FindPost.FindPostResponse)
-  )
+  FindBlogPost: either(QueryErrors, BlogRsc.FindPost.FindPostResponse).optional
 }) {}

--- a/_project/resources/_src/Graph/utils.ts
+++ b/_project/resources/_src/Graph/utils.ts
@@ -3,21 +3,21 @@ import type { Property, PropertyRecord, SchemaAny, SchemaProperties } from "@eff
 export function makeInput<Self extends SchemaAny>(
   a: Self
 ): SchemaProperties<{
-  input: Property<Self, "required", None, None>
+  input: Property<Self, "required", None<any>, None<any>>
 }>
 export function makeInput<Self extends SchemaAny>(
   a: Self,
   noInput: true
 ): SchemaProperties<{
-  input: Property<Self, "optional", None, None>
+  input: Property<Self, "optional", None<any>, None<any>>
 }>
 export function makeInput<Self extends SchemaAny>(a: Self, noInput?: boolean): any {
-  return props(noInput ? { input: optProp(a) } : { input: prop(a) })
+  return props(noInput ? { input: a.optional } : { input: a })
 }
 
 export function makeMutationInput<Props extends PropertyRecord>(baseSchemaProps: Props) {
   return <Self extends SchemaAny>(a: Self) => {
-    const query = props({ ...baseSchemaProps, result: optProp(bool) })
-    return props({ input: prop(a), query: optProp(query) })
+    const query = props({ ...baseSchemaProps, result: bool.optional })
+    return props({ input: a, query: query.optional })
   }
 }

--- a/_project/resources/_src/Graph/utils.ts
+++ b/_project/resources/_src/Graph/utils.ts
@@ -1,0 +1,23 @@
+import type { Property, PropertyRecord, SchemaAny, SchemaProperties } from "@effect-app/prelude/schema"
+
+export function makeInput<Self extends SchemaAny>(
+  a: Self
+): SchemaProperties<{
+  input: Property<Self, "required", None, None>
+}>
+export function makeInput<Self extends SchemaAny>(
+  a: Self,
+  noInput: true
+): SchemaProperties<{
+  input: Property<Self, "optional", None, None>
+}>
+export function makeInput<Self extends SchemaAny>(a: Self, noInput?: boolean): any {
+  return props(noInput ? { input: optProp(a) } : { input: prop(a) })
+}
+
+export function makeMutationInput<Props extends PropertyRecord>(baseSchemaProps: Props) {
+  return <Self extends SchemaAny>(a: Self) => {
+    const query = props({ ...baseSchemaProps, result: optProp(bool) })
+    return props({ input: prop(a), query: optProp(query) })
+  }
+}

--- a/_project/resources/_src/Operations/Find.ts
+++ b/_project/resources/_src/Operations/Find.ts
@@ -2,6 +2,7 @@ import { nullable } from "@effect-app/prelude/schema"
 import { Operation, OperationId } from "../Views.js"
 
 @allowRoles("user")
+@allowAnonymous
 export class FindOperationRequest extends Get("/operations/:id")<FindOperationRequest>()({
   id: OperationId
 }) {}

--- a/_project/resources/_src/errors.ts
+++ b/_project/resources/_src/errors.ts
@@ -1,32 +1,32 @@
-@useClassNameForSchema
+@useClassFeaturesForSchema
 export class NotFoundError extends Model<NotFoundError>()({
   _tag: prop(literal("NotFoundError")),
   message: prop(string)
 }) {}
 
-@useClassNameForSchema
+@useClassFeaturesForSchema
 export class InvalidStateError extends Model<InvalidStateError>()({
   _tag: prop(literal("InvalidStateError")),
   message: prop(string)
 }) {}
 
-@useClassNameForSchema
+@useClassFeaturesForSchema
 export class ValidationError extends Model<ValidationError>()({
   _tag: prop(literal("ValidationError")),
   errors: prop(array(unknown)) // meh
 }) {}
 
-@useClassNameForSchema
+@useClassFeaturesForSchema
 export class NotLoggedInError extends Model<NotLoggedInError>()({
   _tag: prop(literal("NotLoggedInError"))
 }) {}
 
-@useClassNameForSchema
+@useClassFeaturesForSchema
 export class UnauthorizedError extends Model<UnauthorizedError>()({
   _tag: prop(literal("UnauthorizedError"))
 }) {}
 
-@useClassNameForSchema
+@useClassFeaturesForSchema
 export class OptimisticConcurrencyException extends Model<OptimisticConcurrencyException>()(
   {
     _tag: prop(literal("OptimisticConcurrencyException"))

--- a/_project/resources/_src/errors.ts
+++ b/_project/resources/_src/errors.ts
@@ -1,0 +1,70 @@
+@useClassNameForSchema
+export class NotFoundError extends Model<NotFoundError>()({
+  _tag: prop(literal("NotFoundError")),
+  message: prop(string)
+}) {}
+
+@useClassNameForSchema
+export class InvalidStateError extends Model<InvalidStateError>()({
+  _tag: prop(literal("InvalidStateError")),
+  message: prop(string)
+}) {}
+
+@useClassNameForSchema
+export class ValidationError extends Model<ValidationError>()({
+  _tag: prop(literal("ValidationError")),
+  errors: prop(array(unknown)) // meh
+}) {}
+
+@useClassNameForSchema
+export class NotLoggedInError extends Model<NotLoggedInError>()({
+  _tag: prop(literal("NotLoggedInError"))
+}) {}
+
+@useClassNameForSchema
+export class UnauthorizedError extends Model<UnauthorizedError>()({
+  _tag: prop(literal("UnauthorizedError"))
+}) {}
+
+@useClassNameForSchema
+export class OptimisticConcurrencyException extends Model<OptimisticConcurrencyException>()(
+  {
+    _tag: prop(literal("OptimisticConcurrencyException"))
+  }
+) {}
+
+const MutationOnlyErrors = {
+  InvalidStateError,
+  OptimisticConcurrencyException
+}
+
+const GeneralErrors = {
+  NotFoundError,
+  NotLoggedInError,
+  UnauthorizedError,
+  ValidationError
+}
+
+export const SupportedErrors = union({
+  ...MutationOnlyErrors,
+  ...GeneralErrors
+})
+  ["|>"](named("SupportedErrors"))
+  ["|>"](withDefaults)
+export type SupportedErrors = ParsedShapeOf<typeof SupportedErrors>
+
+// ideal?
+// export const QueryErrors = union({ ...GeneralErrors })
+//   ["|>"](named("QueryErrors"))
+//   ["|>"](withDefaults)
+// export type QueryErrors = ParsedShapeOf<typeof QueryErrors>
+// export const MutationErrors = union({ ...GeneralErrors, ...GeneralErrors })
+//   ["|>"](named("MutationErrors"))
+//   ["|>"](withDefaults)
+
+// export type MutationErrors = ParsedShapeOf<typeof MutationErrors>
+
+export const MutationErrors = SupportedErrors
+export const QueryErrors = SupportedErrors
+export type MutationErrors = ParsedShapeOf<typeof MutationErrors>
+export type QueryErrors = ParsedShapeOf<typeof QueryErrors>

--- a/_project/resources/_src/index.ts
+++ b/_project/resources/_src/index.ts
@@ -3,6 +3,7 @@ import "./lib/operations.js"
 export { ClientEvents } from "./Events.js"
 
 // codegen:start {preset: barrel, include: ./*.ts, exclude: [./_global*.ts, ./index.ts, ./lib.ts, ./Views.ts, ./errors.ts], export: { as: 'PascalCase', postfix: 'Rsc' }}
+export * as BlogRsc from "./Blog.js"
 export * as EventsRsc from "./Events.js"
 export * as HelloWorldRsc from "./HelloWorld.js"
 export * as MeRsc from "./Me.js"

--- a/_project/resources/_src/index.ts
+++ b/_project/resources/_src/index.ts
@@ -5,6 +5,7 @@ export { ClientEvents } from "./Events.js"
 // codegen:start {preset: barrel, include: ./*.ts, exclude: [./_global*.ts, ./index.ts, ./lib.ts, ./Views.ts, ./errors.ts], export: { as: 'PascalCase', postfix: 'Rsc' }}
 export * as BlogRsc from "./Blog.js"
 export * as EventsRsc from "./Events.js"
+export * as GraphRsc from "./Graph.js"
 export * as HelloWorldRsc from "./HelloWorld.js"
 export * as MeRsc from "./Me.js"
 export * as OperationsRsc from "./Operations.js"


### PR DESCRIPTION
Converts some endpoints to a GraphQL like experience:
- Combine multiple queries into a single request. batch queries.
- Optionally request follow-up queries to mutations. so within a single roundtrip we can mutate, and query.
- RPC semantics, so all supported errors are returned within Either Left, instead of encoded to and from HTTP Status Codes + Bodies.

TODOs
- improve type inference; when requesting `result` or additional follow-up queries, the response type should no longer have these fields optional.
- improve ergonomics, unwrap the Eithers

Future
- select individual fields (concept already done)